### PR TITLE
Add i18n with Hebrew default

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
+import { useI18n, Lang } from '../i18n'
 
 export default function Navbar() {
   const [open, setOpen] = useState(false)
+  const { t, lang, setLang } = useI18n()
 
   const toggleMenu = () => setOpen((o) => !o)
 
@@ -30,21 +32,30 @@ export default function Navbar() {
             />
           </svg>
         </button>
-        <div className="hidden md:flex space-x-4">
-          <Link to="/dashboard" className="text-gray-700 hover:text-blue-600">Dashboard</Link>
-          <Link to="/orders/new" className="text-gray-700 hover:text-blue-600">New Order</Link>
-          <Link to="/viewer" className="text-gray-700 hover:text-blue-600">Viewer</Link>
-          <Link to="/settings" className="text-gray-700 hover:text-blue-600">Settings</Link>
+        <div className="hidden md:flex space-x-4 items-center">
+          <Link to="/dashboard" className="text-gray-700 hover:text-blue-600">{t('navbar.dashboard')}</Link>
+          <Link to="/orders/new" className="text-gray-700 hover:text-blue-600">{t('navbar.newOrder')}</Link>
+          <Link to="/viewer" className="text-gray-700 hover:text-blue-600">{t('navbar.viewer')}</Link>
+          <Link to="/settings" className="text-gray-700 hover:text-blue-600">{t('navbar.settings')}</Link>
+          <select
+            value={lang}
+            onChange={(e) => setLang(e.target.value as Lang)}
+            className="ml-2 border border-gray-300 rounded"
+            data-testid="lang-select"
+          >
+            <option value="he">עברית</option>
+            <option value="en">English</option>
+          </select>
         </div>
       </div>
       <div
         className={`mt-2 space-y-2 md:hidden ${open ? 'block' : 'hidden'}`}
         data-testid="mobile-menu"
       >
-        <Link to="/dashboard" className="block text-gray-700 hover:text-blue-600">Dashboard</Link>
-        <Link to="/orders/new" className="block text-gray-700 hover:text-blue-600">New Order</Link>
-        <Link to="/viewer" className="block text-gray-700 hover:text-blue-600">Viewer</Link>
-        <Link to="/settings" className="block text-gray-700 hover:text-blue-600">Settings</Link>
+        <Link to="/dashboard" className="block text-gray-700 hover:text-blue-600">{t('navbar.dashboard')}</Link>
+        <Link to="/orders/new" className="block text-gray-700 hover:text-blue-600">{t('navbar.newOrder')}</Link>
+        <Link to="/viewer" className="block text-gray-700 hover:text-blue-600">{t('navbar.viewer')}</Link>
+        <Link to="/settings" className="block text-gray-700 hover:text-blue-600">{t('navbar.settings')}</Link>
       </div>
     </nav>
   )

--- a/src/components/__tests__/Navbar.test.tsx
+++ b/src/components/__tests__/Navbar.test.tsx
@@ -3,12 +3,15 @@ import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
 import Navbar from '../Navbar'
+import { I18nProvider } from '../../i18n'
 
 describe('Navbar', () => {
   it('renders desktop links', () => {
     render(
       <BrowserRouter>
-        <Navbar />
+        <I18nProvider initialLang="en">
+          <Navbar />
+        </I18nProvider>
       </BrowserRouter>
     )
     expect(screen.getAllByText('Dashboard')[0]).toBeInTheDocument()
@@ -19,7 +22,9 @@ describe('Navbar', () => {
     const user = userEvent.setup()
     render(
       <BrowserRouter>
-        <Navbar />
+        <I18nProvider initialLang="en">
+          <Navbar />
+        </I18nProvider>
       </BrowserRouter>
     )
     const menu = screen.getByTestId('mobile-menu')

--- a/src/i18n/__tests__/i18n.test.tsx
+++ b/src/i18n/__tests__/i18n.test.tsx
@@ -1,0 +1,14 @@
+import { renderHook, act } from '@testing-library/react'
+import { I18nProvider, useI18n } from '../index'
+
+it('provides translations and allows switching languages', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <I18nProvider initialLang="en">{children}</I18nProvider>
+  )
+  const { result } = renderHook(() => useI18n(), { wrapper })
+  expect(result.current.t('login.title')).toBe('Log in')
+  act(() => {
+    result.current.setLang('he')
+  })
+  expect(result.current.t('login.title')).toBe('\u05d4\u05ea\u05d7\u05d1\u05e8')
+})

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1,0 +1,208 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+export type Lang = 'he' | 'en'
+
+interface I18nContextValue {
+  lang: Lang
+  setLang: (lang: Lang) => void
+  t: (key: string, params?: Record<string, string | number>) => string
+}
+
+const translations: Record<Lang, Record<string, string>> = {
+  en: {
+    'navbar.dashboard': 'Dashboard',
+    'navbar.newOrder': 'New Order',
+    'navbar.viewer': 'Viewer',
+    'navbar.settings': 'Settings',
+    'dashboard.title': 'Orders',
+    'dashboard.newOrder': '+ New Order',
+    'dashboard.filter': 'Filter:',
+    'dashboard.all': 'All',
+    'status.new': 'New',
+    'status.inProduction': 'In Production',
+    'status.completed': 'Completed',
+    'status.cancelled': 'Cancelled',
+    'dashboard.noOrders': 'No orders yet. Create one to get started.',
+    'login.title': 'Log in',
+    'login.email': 'Email',
+    'login.password': 'Password',
+    'login.submit': 'Log in',
+    'login.submitLoading': 'Logging in...',
+    'login.signupPrompt': "Don\u2019t have an account?",
+    'login.signupLink': 'Sign up',
+    'signup.title': 'Sign up',
+    'signup.name': 'Name',
+    'signup.email': 'Email',
+    'signup.password': 'Password',
+    'signup.confirmPassword': 'Confirm Password',
+    'signup.submit': 'Sign up',
+    'signup.submitLoading': 'Signing up...',
+    'signup.loginPrompt': 'Already have an account?',
+    'signup.loginLink': 'Log in',
+    'signup.passwordMismatch': 'Passwords do not match',
+    'newOrder.title': 'New Order',
+    'newOrder.customerName': 'Customer Name',
+    'newOrder.phone': 'Phone',
+    'newOrder.address': 'Address',
+    'newOrder.surfaceType': 'Surface Type',
+    'newOrder.material': 'Material',
+    'surface.kitchen': 'Kitchen',
+    'surface.bathroom': 'Bathroom',
+    'surface.bar': 'Bar',
+    'surface.other': 'Other',
+    'material.quartz': 'Quartz',
+    'material.granite': 'Granite',
+    'material.marble': 'Marble',
+    'material.concrete': 'Concrete',
+    'newOrder.addSlabPiece': 'Add Slab Piece',
+    'newOrder.width': 'Width (cm)',
+    'newOrder.x': 'X (cm)',
+    'newOrder.y': 'Y (cm)',
+    'newOrder.height': 'Height (cm)',
+    'newOrder.cutouts': 'Cutouts',
+    'newOrder.addCutout': '+ Add Cutout',
+    'newOrder.noCutouts': 'No cutouts defined.',
+    'newOrder.remove': 'Remove',
+    'newOrder.uploadPhoto': 'Upload Photo',
+    'newOrder.addPiece': '+ Add Piece',
+    'newOrder.pieces': 'Pieces',
+    'newOrder.create': 'Create Order',
+    'newOrder.completeAlert': 'Please complete all order details and add at least one piece.',
+    'orderDetails.title': 'Order Details',
+    'orderDetails.back': 'Back to Dashboard',
+    'orderDetails.customer': 'Customer:',
+    'orderDetails.phone': 'Phone:',
+    'orderDetails.address': 'Address:',
+    'orderDetails.surfaceType': 'Surface Type:',
+    'orderDetails.material': 'Material:',
+    'orderDetails.status': 'Status:',
+    'orderDetails.pieces': 'Pieces',
+    'orderDetails.view3d': '3D View',
+    'orderDetails.dimensions': 'Dimensions: {width} × {height} cm',
+    'orderDetails.cutouts': 'Cutouts: {count}',
+    'slabViewer.notFound': 'Slab not found.',
+    'slabViewer.back': '\u2190 Back to Order',
+    'slabViewer.title': '3D Slab Viewer',
+    'slabViewer.material': 'Material',
+    'slabViewer.downloadPdf': 'Download PDF',
+    'settings.title': 'Settings',
+    'settings.token': 'Your token:',
+    'settings.logout': 'Log out'
+  },
+  he: {
+    'navbar.dashboard': '\u05dc\u05d5\u05d7 \u05d1\u05e7\u05e8\u05d4',
+    'navbar.newOrder': '\u05d4\u05d6\u05de\u05e0\u05d4 \u05d7\u05d3\u05e9\u05d4',
+    'navbar.viewer': '\u05de\u05e6\u05d9\u05d2',
+    'navbar.settings': '\u05d4\u05d2\u05d3\u05e8\u05d5\u05ea',
+    'dashboard.title': '\u05d4\u05d6\u05de\u05e0\u05d5\u05ea',
+    'dashboard.newOrder': '+ \u05d4\u05d6\u05de\u05e0\u05d4 \u05d7\u05d3\u05e9\u05d4',
+    'dashboard.filter': '\u05e1\u05d9\u05e0\u05d5\u05df:',
+    'dashboard.all': '\u05d4\u05db\u05dc',
+    'status.new': '\u05d7\u05d3\u05e9',
+    'status.inProduction': '\u05d1\u05d9\u05e6\u05d5\u05e8',
+    'status.completed': '\u05d4\u05d5\u05e9\u05dc\u05dd',
+    'status.cancelled': '\u05d1\u05d5\u05d8\u05dc',
+    'dashboard.noOrders': '\u05d0\u05d9\u05df \u05d4\u05d6\u05de\u05e0\u05d5\u05ea. \u05e6\u05d5\u05e8 \u05d4\u05d6\u05de\u05e0\u05d4 \u05db\u05d3\u05d9 להתחיל.',
+    'login.title': '\u05d4\u05ea\u05d7\u05d1\u05e8',
+    'login.email': '\u05d0\u05d9\u05de\u05d9\u05d9\u05dc',
+    'login.password': '\u05e1\u05d9\u05e1\u05de\u05d4',
+    'login.submit': '\u05d4\u05ea\u05d7\u05d1\u05e8',
+    'login.submitLoading': '\u05d4\u05ea\u05d7\u05d1\u05e8...',
+    'login.signupPrompt': '\u05d0\u05d9\u05df \u05dc\u05da \u05d7\u05e9\u05d1\u05d5\u05df?',
+    'login.signupLink': '\u05d4\u05e8\u05e9\u05dd',
+    'signup.title': '\u05d4\u05e8\u05e9\u05dd',
+    'signup.name': '\u05e9\u05dd',
+    'signup.email': '\u05d0\u05d9\u05de\u05d9\u05d9\u05dc',
+    'signup.password': '\u05e1\u05d9\u05e1\u05de\u05d4',
+    'signup.confirmPassword': '\u05d0\u05d9\u05e9\u05d5\u05e8 \u05e1\u05d9\u05e1\u05de\u05d4',
+    'signup.submit': '\u05d4\u05e8\u05e9\u05dd',
+    'signup.submitLoading': '\u05e0\u05e8\u05e9\u05dd...',
+    'signup.loginPrompt': '\u05db\u05d1\u05e8 \u05d7\u05e9\u05d1\u05d5\u05df?',
+    'signup.loginLink': '\u05d4\u05ea\u05d7\u05d1\u05e8',
+    'signup.passwordMismatch': '\u05e1\u05d9\u05e1\u05de\u05d5\u05ea \u05d0\u05d9\u05e0\u05df \u05d7\u05d5\u05e4\u05e4\u05d5\u05ea',
+    'newOrder.title': '\u05d4\u05d6\u05de\u05e0\u05d4 \u05d7\u05d3\u05e9\u05d4',
+    'newOrder.customerName': '\u05e9\u05dd \u05dc\u05e7\u05d5\u05d7',
+    'newOrder.phone': '\u05d8\u05dc\u05e4\u05d5\u05df',
+    'newOrder.address': '\u05db\u05ea\u05d5\u05d1\u05ea',
+    'newOrder.surfaceType': '\u05e1\u05d5\u05d2 \u05e9\u05d7\u05d5\u05ea',
+    'newOrder.material': '\u05d7\u05d5\u05de\u05e8',
+    'surface.kitchen': '\u05de\u05d8\u05d1\u05d7',
+    'surface.bathroom': '\u05d7\u05d3\u05e8 \u05d0\u05de\u05d1\u05d8\u05d9\u05d4',
+    'surface.bar': '\u05d1\u05e8',
+    'surface.other': '\u05d0\u05d7\u05e8',
+    'material.quartz': '\u05e7\u05d5\u05f2\u05e8\u05e5',
+    'material.granite': '\u05d2\u05e8\u05e0\u05d9\u05d8',
+    'material.marble': '\u05e9\u05d9\u05e9',
+    'material.concrete': '\u05d1\u05d8\u05d5\u05df',
+    'newOrder.addSlabPiece': '\u05d4\u05d5\u05e1\u05e3 \u05e7\u05d8\u05e2 \u05dc\u05d5\u05d7\u05d4',
+    'newOrder.width': '\u05e8\u05d5\u05d7\u05d1 (cm)',
+    'newOrder.x': 'X (cm)',
+    'newOrder.y': 'Y (cm)',
+    'newOrder.height': '\u05d2\u05d5\u05d1\u05d4 (cm)',
+    'newOrder.cutouts': '\u05e7\u05d9\u05e2\u05d5\u05ea',
+    'newOrder.addCutout': '+ \u05d4\u05d5\u05e1\u05e3 \u05e7\u05d9\u05e2\u05d4',
+    'newOrder.noCutouts': '\u05d0\u05d9\u05df \u05e7\u05d9\u05e2\u05d5\u05ea.',
+    'newOrder.remove': '\u05d4\u05e1\u05e8',
+    'newOrder.uploadPhoto': '\u05d4\u05e2\u05dcה \u05eaמונה',
+    'newOrder.addPiece': '+ \u05d4וספת \u05e7\u05d8\u05e2',
+    'newOrder.pieces': '\u05e7\u05d8\u05e2\u05d9\u05dd',
+    'newOrder.create': '\u05e6\u05d5\u05e8 \u05d4\u05d6\u05de\u05e0\u05d4',
+    'newOrder.completeAlert': '\u05d4\u05e9\u05dc\u05dd \u05d0\u05ea \u05db\u05dc \u05e4\u05e8\u05d8\u05d9 \u05d4\u05d4זמנה \u05d5הוסף \u05dcפחות \u05e7\u05d8\u05e2 אחד.',
+    'orderDetails.title': '\u05e4\u05e8\u05d8\u05d9 \u05d4זמנ\u05d4',
+    'orderDetails.back': '\u05d7\u05d6\u05e8 \u05dc\u05dcוח \u05d1\u05e7\u05e8\u05d4',
+    'orderDetails.customer': '\u05dc\u05e7וח:',
+    'orderDetails.phone': '\u05d8\u05dcפון:',
+    'orderDetails.address': '\u05dbתובת:',
+    'orderDetails.surfaceType': '\u05e1וג \u05e9חות:',
+    'orderDetails.material': '\u05d7ומר:',
+    'orderDetails.status': '\u05d1מע:',
+    'orderDetails.pieces': '\u05e7\u05d8\u05e2\u05d9\u05dd',
+    'orderDetails.view3d': '3D \u05e6\u05e4\u05d9\u05d4',
+    'orderDetails.dimensions': '\u05de\u05de\u05d3\u05d9\u05dd: {width} \u00d7 {height} cm',
+    'orderDetails.cutouts': '\u05e7\u05d9\u05e2\u05d5\u05ea: {count}',
+    'slabViewer.notFound': '\u05dcוח \u05dc\u05d0 \u05e0\u05deצא.',
+    'slabViewer.back': '\u2190 \u05d7\u05d6\u05e8 \u05dc\u05d4זמנה',
+    'slabViewer.title': '3D \u05deציג \u05dcוח',
+    'slabViewer.material': '\u05d7ומר',
+    'slabViewer.downloadPdf': '\u05d4ורד PDF',
+    'settings.title': '\u05d4\u05d2\u05d3\u05e8\u05d5\u05ea',
+    'settings.token': '\u05d4\u05d8\u05d5\u05e7\u05df \u05e9\u05dcך:',
+    'settings.logout': '\u05d4\u05ea\u05e0\u05ea\u05e7'
+  }
+}
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined)
+
+export function I18nProvider({ children, initialLang }: { children: React.ReactNode; initialLang?: Lang }) {
+  const [lang, setLangState] = useState<Lang>(initialLang || 'he')
+
+  useEffect(() => {
+    if (!initialLang) {
+      const stored = localStorage.getItem('lang') as Lang | null
+      if (stored === 'en' || stored === 'he') {
+        setLangState(stored)
+      }
+    }
+  }, [initialLang])
+
+  const setLang = (l: Lang) => {
+    setLangState(l)
+    localStorage.setItem('lang', l)
+  }
+
+  const t = (key: string, params?: Record<string, string | number>) => {
+    const str = translations[lang][key] || translations.he[key] || translations.en[key] || key
+    if (!params) return str
+    return str.replace(/\{(\w+)\}/g, (_, k) => String(params[k] ?? ''))
+  }
+
+  return <I18nContext.Provider value={{ lang, setLang, t }}>{children}</I18nContext.Provider>
+}
+
+export function useI18n() {
+  const ctx = useContext(I18nContext)
+  if (!ctx) {
+    throw new Error('useI18n must be used within I18nProvider')
+  }
+  return ctx
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,13 +3,16 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AuthProvider } from './hooks/useAuth'; // 👈 Make sure this path is correct
+import { I18nProvider } from './i18n';
 import './styles/index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
       <AuthProvider>
-        <App />
+        <I18nProvider>
+          <App />
+        </I18nProvider>
       </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { getOrders, Order, OrderStatus } from '../services/orders';
+import { useI18n } from '../i18n';
 
 /**
  * Dashboard page component.
@@ -14,32 +15,33 @@ export default function DashboardPage() {
   const [statusFilter, setStatusFilter] = useState<OrderStatus | 'All'>('All');
   const orders = useMemo(() => getOrders(), []);
   const filtered = statusFilter === 'All' ? orders : orders.filter((o) => o.status === statusFilter);
+  const { t } = useI18n();
 
   return (
     <div className="p-4 pb-20 md:pb-4 space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold">Orders</h2>
+        <h2 className="text-2xl font-bold">{t('dashboard.title')}</h2>
         <Link to="/orders/new" className="bg-accent text-white px-4 py-2 rounded-md shadow hover:bg-orange-600">
-          + New Order
+          {t('dashboard.newOrder')}
         </Link>
       </div>
       <div className="flex items-center space-x-2">
-        <label htmlFor="status" className="text-sm font-medium">Filter:</label>
+        <label htmlFor="status" className="text-sm font-medium">{t('dashboard.filter')}</label>
         <select
           id="status"
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value as OrderStatus | 'All')}
           className="bg-white"
         >
-          <option value="All">All</option>
-          <option value="New">New</option>
-          <option value="In Production">In Production</option>
-          <option value="Completed">Completed</option>
-          <option value="Cancelled">Cancelled</option>
+          <option value="All">{t('dashboard.all')}</option>
+          <option value="New">{t('status.new')}</option>
+          <option value="In Production">{t('status.inProduction')}</option>
+          <option value="Completed">{t('status.completed')}</option>
+          <option value="Cancelled">{t('status.cancelled')}</option>
         </select>
       </div>
       {filtered.length === 0 ? (
-        <p className="text-stone-500">No orders yet. Create one to get started.</p>
+        <p className="text-stone-500">{t('dashboard.noOrders')}</p>
       ) : (
         <ul className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {filtered.map((order) => (

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import { useI18n } from '../i18n';
 
 /**
  * Login page component.
@@ -13,6 +14,7 @@ import { useAuth } from '../hooks/useAuth';
 export default function LoginPage() {
   const { login } = useAuth();
   const navigate = useNavigate();
+  const { t } = useI18n();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -35,14 +37,14 @@ export default function LoginPage() {
   return (
     <div className="flex items-center justify-center min-h-screen px-4 pt-20 md:pt-0">
       <div className="w-full max-w-md p-6 bg-white rounded-lg shadow-md">
-        <h2 className="text-2xl font-bold mb-6 text-center">Log in</h2>
+        <h2 className="text-2xl font-bold mb-6 text-center">{t('login.title')}</h2>
         {error && (
           <div className="mb-4 text-red-600 text-sm text-center">{error}</div>
         )}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-stone-700">
-              Email
+              {t('login.email')}
             </label>
             <input
               id="email"
@@ -56,7 +58,7 @@ export default function LoginPage() {
           </div>
           <div>
             <label htmlFor="password" className="block text-sm font-medium text-stone-700">
-              Password
+              {t('login.password')}
             </label>
             <input
               id="password"
@@ -73,13 +75,13 @@ export default function LoginPage() {
             disabled={loading}
             className="w-full bg-primary text-white py-2 rounded-md hover:bg-blue-700 disabled:opacity-50"
           >
-            {loading ? 'Logging in...' : 'Log in'}
+            {loading ? t('login.submitLoading') : t('login.submit')}
           </button>
         </form>
         <p className="mt-4 text-center text-sm">
-          Don’t have an account?{' '}
+          {t('login.signupPrompt')} {' '}
           <Link to="/signup" className="text-blue-600 hover:underline">
-            Sign up
+            {t('login.signupLink')}
           </Link>
         </p>
       </div>

--- a/src/pages/NewOrderPage.tsx
+++ b/src/pages/NewOrderPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createOrder, Piece, Cutout } from '../services/orders';
+import { useI18n } from '../i18n';
 import { v4 as uuidv4 } from 'uuid';
 
 /**
@@ -14,6 +15,7 @@ import { v4 as uuidv4 } from 'uuid';
  */
 export default function NewOrderPage() {
   const navigate = useNavigate();
+  const { t } = useI18n();
   const [customerName, setCustomerName] = useState('');
   const [phone, setPhone] = useState('');
   const [address, setAddress] = useState('');
@@ -76,7 +78,7 @@ export default function NewOrderPage() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!customerName || !phone || !address || pieces.length === 0) {
-      alert('Please complete all order details and add at least one piece.');
+      alert(t('newOrder.completeAlert'));
       return;
     }
     const order = createOrder({
@@ -92,11 +94,11 @@ export default function NewOrderPage() {
 
   return (
     <div className="p-4 pb-24 md:pb-4 space-y-6">
-      <h2 className="text-2xl font-bold">New Order</h2>
+      <h2 className="text-2xl font-bold">{t('newOrder.title')}</h2>
       <form onSubmit={handleSubmit} className="space-y-6">
         <div className="grid gap-4 md:grid-cols-2">
           <div>
-            <label className="block text-sm font-medium mb-1">Customer Name</label>
+            <label className="block text-sm font-medium mb-1">{t('newOrder.customerName')}</label>
             <input
               type="text"
               value={customerName}
@@ -106,7 +108,7 @@ export default function NewOrderPage() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Phone</label>
+            <label className="block text-sm font-medium mb-1">{t('newOrder.phone')}</label>
             <input
               type="tel"
               value={phone}
@@ -116,7 +118,7 @@ export default function NewOrderPage() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Address</label>
+            <label className="block text-sm font-medium mb-1">{t('newOrder.address')}</label>
             <input
               type="text"
               value={address}
@@ -126,30 +128,30 @@ export default function NewOrderPage() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Surface Type</label>
+            <label className="block text-sm font-medium mb-1">{t('newOrder.surfaceType')}</label>
             <select value={surfaceType} onChange={(e) => setSurfaceType(e.target.value)} className="w-full bg-white">
-              <option>Kitchen</option>
-              <option>Bathroom</option>
-              <option>Bar</option>
-              <option>Other</option>
+              <option>{t('surface.kitchen')}</option>
+              <option>{t('surface.bathroom')}</option>
+              <option>{t('surface.bar')}</option>
+              <option>{t('surface.other')}</option>
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Material</label>
+            <label className="block text-sm font-medium mb-1">{t('newOrder.material')}</label>
             <select value={material} onChange={(e) => setMaterial(e.target.value)} className="w-full bg-white">
-              <option>Quartz</option>
-              <option>Granite</option>
-              <option>Marble</option>
-              <option>Concrete</option>
+              <option>{t('material.quartz')}</option>
+              <option>{t('material.granite')}</option>
+              <option>{t('material.marble')}</option>
+              <option>{t('material.concrete')}</option>
             </select>
           </div>
         </div>
         {/* Piece definition */}
         <div className="border-t pt-6">
-          <h3 className="text-xl font-semibold mb-4">Add Slab Piece</h3>
+          <h3 className="text-xl font-semibold mb-4">{t('newOrder.addSlabPiece')}</h3>
           <div className="grid gap-4 md:grid-cols-2">
             <div>
-              <label className="block text-sm font-medium mb-1">Width (cm)</label>
+              <label className="block text-sm font-medium mb-1">{t('newOrder.width')}</label>
               <input
                 type="number"
                 value={pieceWidth}
@@ -159,7 +161,7 @@ export default function NewOrderPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Height (cm)</label>
+              <label className="block text-sm font-medium mb-1">{t('newOrder.height')}</label>
               <input
                 type="number"
                 value={pieceHeight}
@@ -172,20 +174,20 @@ export default function NewOrderPage() {
           {/* Cutouts Section */}
           <div className="mt-4 space-y-4">
             <div className="flex items-center justify-between">
-              <h4 className="font-medium">Cutouts</h4>
+              <h4 className="font-medium">{t('newOrder.cutouts')}</h4>
               <button
                 type="button"
                 onClick={handleAddCutout}
                 className="text-sm text-blue-600 hover:underline"
               >
-                + Add Cutout
+                {t('newOrder.addCutout')}
               </button>
             </div>
-            {cutouts.length === 0 && <p className="text-sm text-stone-500">No cutouts defined.</p>}
+            {cutouts.length === 0 && <p className="text-sm text-stone-500">{t('newOrder.noCutouts')}</p>}
             {cutouts.map((cutout, idx) => (
               <div key={idx} className="grid gap-2 grid-cols-4 items-end">
                 <div>
-                  <label className="block text-xs mb-1">X (cm)</label>
+                  <label className="block text-xs mb-1">{t('newOrder.x')}</label>
                   <input
                     type="number"
                     value={cutout.x}
@@ -195,7 +197,7 @@ export default function NewOrderPage() {
                   />
                 </div>
                 <div>
-                  <label className="block text-xs mb-1">Y (cm)</label>
+                  <label className="block text-xs mb-1">{t('newOrder.y')}</label>
                   <input
                     type="number"
                     value={cutout.y}
@@ -205,7 +207,7 @@ export default function NewOrderPage() {
                   />
                 </div>
                 <div>
-                  <label className="block text-xs mb-1">Width (cm)</label>
+                  <label className="block text-xs mb-1">{t('newOrder.width')}</label>
                   <input
                     type="number"
                     value={cutout.width}
@@ -215,7 +217,7 @@ export default function NewOrderPage() {
                   />
                 </div>
                 <div>
-                  <label className="block text-xs mb-1">Height (cm)</label>
+                  <label className="block text-xs mb-1">{t('newOrder.height')}</label>
                   <input
                     type="number"
                     value={cutout.height}
@@ -229,14 +231,14 @@ export default function NewOrderPage() {
                   onClick={() => handleRemoveCutout(idx)}
                   className="text-xs text-red-600 hover:underline ml-2"
                 >
-                  Remove
+                  {t('newOrder.remove')}
                 </button>
               </div>
             ))}
           </div>
           {/* Photo upload */}
           <div className="mt-4">
-            <label className="block text-sm font-medium mb-1">Upload Photo</label>
+            <label className="block text-sm font-medium mb-1">{t('newOrder.uploadPhoto')}</label>
             <input type="file" accept="image/*" onChange={handlePhotoChange} />
             {piecePhoto && (
               <img src={piecePhoto} alt="Preview" className="mt-2 w-32 h-32 object-cover rounded" />
@@ -249,13 +251,13 @@ export default function NewOrderPage() {
             disabled={!pieceWidth || !pieceHeight}
             className="mt-4 bg-primary text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50"
           >
-            + Add Piece
+            {t('newOrder.addPiece')}
           </button>
         </div>
         {/* List of added pieces */}
         {pieces.length > 0 && (
           <div className="mt-6">
-            <h3 className="text-xl font-semibold mb-2">Pieces</h3>
+            <h3 className="text-xl font-semibold mb-2">{t('newOrder.pieces')}</h3>
             <ul className="space-y-2">
               {pieces.map((p, idx) => (
                 <li key={p.id} className="border p-3 rounded-md flex items-center justify-between">
@@ -274,7 +276,7 @@ export default function NewOrderPage() {
           type="submit"
           className="w-full bg-accent text-white py-2 rounded-md hover:bg-orange-600"
         >
-          Create Order
+          {t('newOrder.create')}
         </button>
       </form>
     </div>

--- a/src/pages/OrderDetailsPage.tsx
+++ b/src/pages/OrderDetailsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { getOrder, updateOrder, Order, OrderStatus } from '../services/orders';
+import { useI18n } from '../i18n';
 
 /**
  * Order details page component.
@@ -16,6 +17,7 @@ export default function OrderDetailsPage() {
   const navigate = useNavigate();
   const [order, setOrder] = useState<Order | undefined>(undefined);
   const [status, setStatus] = useState<OrderStatus>('New');
+  const { t } = useI18n();
 
   useEffect(() => {
     if (!id) return;
@@ -44,43 +46,43 @@ export default function OrderDetailsPage() {
   return (
     <div className="p-4 pb-20 md:pb-4 space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold">Order Details</h2>
+        <h2 className="text-2xl font-bold">{t('orderDetails.title')}</h2>
         <Link to="/dashboard" className="text-blue-600 hover:underline">
-          Back to Dashboard
+          {t('orderDetails.back')}
         </Link>
       </div>
       <div className="bg-white p-4 rounded-lg shadow space-y-2">
         <p>
-          <span className="font-semibold">Customer:</span> {order.customerName}
+          <span className="font-semibold">{t('orderDetails.customer')}</span> {order.customerName}
         </p>
         <p>
-          <span className="font-semibold">Phone:</span> {order.phone}
+          <span className="font-semibold">{t('orderDetails.phone')}</span> {order.phone}
         </p>
         <p>
-          <span className="font-semibold">Address:</span> {order.address}
+          <span className="font-semibold">{t('orderDetails.address')}</span> {order.address}
         </p>
         <p>
-          <span className="font-semibold">Surface Type:</span> {order.surfaceType}
+          <span className="font-semibold">{t('orderDetails.surfaceType')}</span> {order.surfaceType}
         </p>
         <p>
-          <span className="font-semibold">Material:</span> {order.material}
+          <span className="font-semibold">{t('orderDetails.material')}</span> {order.material}
         </p>
         <div className="flex items-center space-x-2">
-          <span className="font-semibold">Status:</span>
+          <span className="font-semibold">{t('orderDetails.status')}</span>
           <select
             value={status}
             onChange={(e) => handleStatusChange(e.target.value as OrderStatus)}
             className="bg-white border border-stone-300 px-2 py-1 rounded"
           >
-            <option value="New">New</option>
-            <option value="In Production">In Production</option>
-            <option value="Completed">Completed</option>
-            <option value="Cancelled">Cancelled</option>
+            <option value="New">{t('status.new')}</option>
+            <option value="In Production">{t('status.inProduction')}</option>
+            <option value="Completed">{t('status.completed')}</option>
+            <option value="Cancelled">{t('status.cancelled')}</option>
           </select>
         </div>
       </div>
       <div>
-        <h3 className="text-xl font-semibold mb-2">Pieces</h3>
+        <h3 className="text-xl font-semibold mb-2">{t('orderDetails.pieces')}</h3>
         <ul className="space-y-4">
           {order.pieces.map((p, idx) => (
             <li key={p.id} className="bg-white p-4 rounded-md shadow">
@@ -90,13 +92,13 @@ export default function OrderDetailsPage() {
                   to={`/viewer/${order.id}/${p.id}`}
                   className="text-blue-600 text-sm hover:underline"
                 >
-                  3D View
+                  {t('orderDetails.view3d')}
                 </Link>
               </div>
               <p className="text-sm text-stone-700">
-                Dimensions: {p.width} × {p.height} cm
+                {t('orderDetails.dimensions', { width: p.width, height: p.height })}
               </p>
-              <p className="text-sm text-stone-700">Cutouts: {p.cutouts.length}</p>
+              <p className="text-sm text-stone-700">{t('orderDetails.cutouts', { count: p.cutouts.length })}</p>
               {p.photo && <img src={p.photo} alt="piece" className="mt-2 w-32 h-32 object-cover rounded" />}
             </li>
           ))}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useAuth } from '../hooks/useAuth';
+import { useI18n } from '../i18n';
 
 /**
  * Settings page component.
@@ -11,13 +12,14 @@ import { useAuth } from '../hooks/useAuth';
  */
 export default function SettingsPage() {
   const { token, logout } = useAuth();
+  const { t } = useI18n();
 
   return (
     <div className="p-4 pb-20 md:pb-4 space-y-4">
-      <h2 className="text-2xl font-bold">Settings</h2>
+      <h2 className="text-2xl font-bold">{t('settings.title')}</h2>
       <div className="bg-white p-4 rounded-lg shadow">
         <p className="text-sm text-stone-700 break-all">
-          <span className="font-semibold">Your token:</span> {token}
+          <span className="font-semibold">{t('settings.token')}</span> {token}
         </p>
       </div>
       <button
@@ -25,7 +27,7 @@ export default function SettingsPage() {
         onClick={logout}
         className="bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-700"
       >
-        Log out
+        {t('settings.logout')}
       </button>
     </div>
   );

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import { useI18n } from '../i18n';
 
 /**
  * Sign up page component.
@@ -13,6 +14,7 @@ import { useAuth } from '../hooks/useAuth';
 export default function SignUpPage() {
   const { register } = useAuth();
   const navigate = useNavigate();
+  const { t } = useI18n();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -24,7 +26,7 @@ export default function SignUpPage() {
     e.preventDefault();
     setError(null);
     if (password !== confirmPassword) {
-      setError('Passwords do not match');
+      setError(t('signup.passwordMismatch'));
       return;
     }
     setLoading(true);
@@ -41,14 +43,14 @@ export default function SignUpPage() {
   return (
     <div className="flex items-center justify-center min-h-screen px-4 pt-20 md:pt-0">
       <div className="w-full max-w-md p-6 bg-white rounded-lg shadow-md">
-        <h2 className="text-2xl font-bold mb-6 text-center">Sign up</h2>
+        <h2 className="text-2xl font-bold mb-6 text-center">{t('signup.title')}</h2>
         {error && (
           <div className="mb-4 text-red-600 text-sm text-center">{error}</div>
         )}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label htmlFor="name" className="block text-sm font-medium text-stone-700">
-              Name
+              {t('signup.name')}
             </label>
             <input
               id="name"
@@ -62,7 +64,7 @@ export default function SignUpPage() {
           </div>
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-stone-700">
-              Email
+              {t('signup.email')}
             </label>
             <input
               id="email"
@@ -76,7 +78,7 @@ export default function SignUpPage() {
           </div>
           <div>
             <label htmlFor="password" className="block text-sm font-medium text-stone-700">
-              Password
+              {t('signup.password')}
             </label>
             <input
               id="password"
@@ -90,7 +92,7 @@ export default function SignUpPage() {
           </div>
           <div>
             <label htmlFor="confirm" className="block text-sm font-medium text-stone-700">
-              Confirm Password
+              {t('signup.confirmPassword')}
             </label>
             <input
               id="confirm"
@@ -107,15 +109,15 @@ export default function SignUpPage() {
             disabled={loading}
             className="w-full bg-primary text-white py-2 rounded-md hover:bg-blue-700 disabled:opacity-50"
           >
-            {loading ? 'Signing up...' : 'Sign up'}
-          </button>
-        </form>
-        <p className="mt-4 text-center text-sm">
-          Already have an account?{' '}
+            {loading ? t('signup.submitLoading') : t('signup.submit')}
+        </button>
+      </form>
+      <p className="mt-4 text-center text-sm">
+          {t('signup.loginPrompt')} {' '}
           <Link to="/login" className="text-blue-600 hover:underline">
-            Log in
+            {t('signup.loginLink')}
           </Link>
-        </p>
+      </p>
       </div>
     </div>
   );

--- a/src/pages/SlabViewerPage.tsx
+++ b/src/pages/SlabViewerPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { getOrder, Order, Piece } from '../services/orders';
+import { useI18n } from '../i18n';
 
 /**
  * Slab viewer page component.
@@ -16,6 +17,7 @@ export default function SlabViewerPage() {
   const [order, setOrder] = useState<Order | undefined>(undefined);
   const [piece, setPiece] = useState<Piece | undefined>(undefined);
   const [material, setMaterial] = useState<string>('Granite');
+  const { t } = useI18n();
 
   useEffect(() => {
     if (!orderId || !pieceId) return;
@@ -29,7 +31,7 @@ export default function SlabViewerPage() {
   if (!order || !piece) {
     return (
       <div className="p-4">
-        <p>Slab not found.</p>
+        <p>{t('slabViewer.notFound')}</p>
       </div>
     );
   }
@@ -47,9 +49,9 @@ export default function SlabViewerPage() {
   return (
     <div className="p-4 space-y-4 pb-20 md:pb-4">
       <Link to={`/orders/${order.id}`} className="text-blue-600 hover:underline">
-        ← Back to Order
+        {t('slabViewer.back')}
       </Link>
-      <h2 className="text-2xl font-bold">3D Slab Viewer</h2>
+      <h2 className="text-2xl font-bold">{t('slabViewer.title')}</h2>
       <div className="flex flex-col md:flex-row md:space-x-8">
         {/* 3D model container */}
         <div className="flex-1 flex items-center justify-center h-64 md:h-96">
@@ -99,16 +101,16 @@ export default function SlabViewerPage() {
         {/* Controls */}
         <div className="w-full md:w-64 space-y-4">
           <div>
-            <label className="block text-sm font-medium mb-1">Material</label>
+            <label className="block text-sm font-medium mb-1">{t('slabViewer.material')}</label>
             <select
               value={material}
               onChange={(e) => setMaterial(e.target.value)}
               className="w-full bg-white"
             >
-              <option>Quartz</option>
-              <option>Granite</option>
-              <option>Marble</option>
-              <option>Concrete</option>
+              <option>{t('material.quartz')}</option>
+              <option>{t('material.granite')}</option>
+              <option>{t('material.marble')}</option>
+              <option>{t('material.concrete')}</option>
             </select>
           </div>
           <button
@@ -116,7 +118,7 @@ export default function SlabViewerPage() {
             className="w-full bg-primary text-white py-2 rounded-md hover:bg-blue-700"
             onClick={() => alert('PDF export not implemented')}
           >
-            Download PDF
+            {t('slabViewer.downloadPdf')}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add simple i18n context with Hebrew and English dictionaries
- wrap application with `I18nProvider`
- translate pages and components
- add language selector in navbar
- update navbar test and add new i18n test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68873537c52483298ced09f2d79b32db