### PR TITLE
Add direction switch with language

### DIFF
--- a/src/i18n/__tests__/i18n.test.tsx
+++ b/src/i18n/__tests__/i18n.test.tsx
@@ -1,14 +1,16 @@
 import { renderHook, act } from '@testing-library/react'
 import { I18nProvider, useI18n } from '../index'
 
-it('provides translations and allows switching languages', () => {
+it('provides translations and updates document direction', () => {
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <I18nProvider initialLang="en">{children}</I18nProvider>
   )
   const { result } = renderHook(() => useI18n(), { wrapper })
+  expect(document.documentElement.dir).toBe('ltr')
   expect(result.current.t('login.title')).toBe('Log in')
   act(() => {
     result.current.setLang('he')
   })
+  expect(document.documentElement.dir).toBe('rtl')
   expect(result.current.t('login.title')).toBe('\u05d4\u05ea\u05d7\u05d1\u05e8')
 })

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -190,6 +190,11 @@ export function I18nProvider({ children, initialLang }: { children: React.ReactN
     localStorage.setItem('lang', l)
   }
 
+  useEffect(() => {
+    document.documentElement.lang = lang
+    document.documentElement.dir = lang === 'he' ? 'rtl' : 'ltr'
+  }, [lang])
+
   const t = (key: string, params?: Record<string, string | number>) => {
     const str = translations[lang][key] || translations.he[key] || translations.en[key] || key
     if (!params) return str


### PR DESCRIPTION
## Summary
- update `I18nProvider` to set HTML `lang` and `dir`
- test language switching updates document direction

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68873e15281c8329a502feb0516722dd