### PR TITLE
Add Capacitor iOS packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,30 @@
 This project uses Vite and React. API requests are made to the backend defined by
 the `VITE_API_URL` environment variable. During local development it defaults to
 `http://localhost:8000`.
+
+## Packaging for iOS
+
+The project is configured with [Capacitor](https://capacitorjs.com) so the web
+build can run inside a native iOS wrapper.
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Add the iOS platform and copy the built web assets:
+
+   ```bash
+   npx cap add ios
+   npm run ios
+   ```
+
+3. Open the iOS project in Xcode to build and deploy to a device:
+
+   ```bash
+   npx cap open ios
+   ```
+
+After building the app in Xcode you can install the resulting `.ipa` on your
+iOS device using TestFlight or a provisioning profile.

--- a/__tests__/capacitor.config.test.ts
+++ b/__tests__/capacitor.config.test.ts
@@ -1,0 +1,9 @@
+import config from '../capacitor.config'
+
+describe('Capacitor config', () => {
+  it('has correct base settings', () => {
+    expect(config.appId).toBe('com.example.stoneflow')
+    expect(config.appName).toBe('Stoneflow')
+    expect(config.webDir).toBe('dist')
+  })
+})

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,0 +1,10 @@
+import { CapacitorConfig } from '@capacitor/cli'
+
+const config: CapacitorConfig = {
+  appId: 'com.example.stoneflow',
+  appName: 'Stoneflow',
+  webDir: 'dist',
+  bundledWebRuntime: false
+}
+
+export default config

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
-    "test": "vitest run --coverage"
+    "test": "vitest run --coverage",
+    "ios": "vite build && npx cap sync ios"
   },
   "dependencies": {
     "@react-three/drei": "^10.6.1",
@@ -21,7 +22,8 @@
     "react-router-dom": "^6.23.0",
     "three": "^0.178.0",
     "use-image": "^1.1.4",
-    "uuid": "*"
+    "uuid": "*",
+    "@capacitor/core": "^5.0.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
@@ -40,6 +42,8 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.4.5",
     "vite": "^5.2.0",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@capacitor/cli": "^5.0.0",
+    "@capacitor/ios": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Capacitor dependencies and ios build script
- create Capacitor configuration
- test configuration object
- document how to package the app for iOS

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6889c4da051c8329b18a3bfb1b7bb8ad